### PR TITLE
SB-0002: Add pre-commit and commit-msg hooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.1] - 2025-04-04
+### Added pre-commit hooks
+- Added the `pre-commit` and `commit-msg` hooks
+
+### Fixed
+- NA
+
+### Changed
+- NA
+
+---
+
 ## [1.0.0] - 2025-03-31
 ### Initial version created
 - GitHub Template repository for Composite Action


### PR DESCRIPTION
This pull request includes an update to the `CHANGELOG.md` file to document the addition of pre-commit hooks in version 1.0.1.

Changes to `CHANGELOG.md`:

* Added a new section for version 1.0.1 dated 2025-04-04.
* Documented the addition of `pre-commit` and `commit-msg` hooks.