### PR TITLE
feat: add release configuration for semantic release

### DIFF
--- a/scripts/plugins/release.config.js
+++ b/scripts/plugins/release.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  branches: ["main"],
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["CHANGELOG.md"],
+        message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+};


### PR DESCRIPTION
This pull request introduces a new configuration file for automating the release process using `semantic-release`. The configuration specifies the branches to monitor and the plugins to use for analyzing commits, generating release notes, updating the changelog, committing changes, and publishing releases on GitHub.

Key changes:

### Release automation setup:

* Added `scripts/plugins/release.config.js` to configure `semantic-release` for automating the release process. The configuration includes:
  - Monitoring the `main` branch for release triggers.
  - Using plugins for commit analysis, release note generation, changelog updates, Git commits, and GitHub releases.