### PR TITLE
fix: update release configuration path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   },
   "release": {
-    "extends": "./release.config.js"
+    "extends": "./scripts/plugins/release.config.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the path to the `release.config.js` file to point to its new location under the `scripts/plugins` directory.