### PR TITLE
feat: add workflow to auto create branches on issue assignment

### DIFF
--- a/.github/workflows/create-branch.yaml
+++ b/.github/workflows/create-branch.yaml
@@ -1,0 +1,18 @@
+name: Auto Create Branch on Issue Assignment
+run-name: Create Feature Branch by ${{ github.actor }} on ${{ github.ref_name }}
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  create-feature-branch:
+    name: "Create Feature Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: subhamay-bhattacharyya-gha/create-branch-action@main
+        with:
+          title-length: 25
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          use-project-prefix: 'false'
+          branch-prefix: 'GHA'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically create a feature branch when an issue is assigned. 

### New Workflow Addition:

* [`.github/workflows/create-branch.yaml`](diffhunk://#diff-66d10b0d536d63265c884183009b0c2e3c462ffe64518186b4d11dfd2db77489R1-R18): Added a workflow named "Auto Create Branch on Issue Assignment" that triggers on issue assignment events. It uses the `create-branch-action` to generate a new branch with a prefix `GHA`, utilizing the GitHub token for authentication.