### PR TITLE
fix: add missing permissions for issue assignment workflow

### DIFF
--- a/.github/workflows/create-branch.yaml
+++ b/.github/workflows/create-branch.yaml
@@ -5,6 +5,10 @@ on:
   issues:
     types: [assigned]
 
+permissions:
+  contents: write
+  issues: write
+  
 jobs:
   create-feature-branch:
     name: "Create Feature Branch"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to adjust permissions for the `create-branch.yaml` workflow file.

### Workflow permissions update:
* [`.github/workflows/create-branch.yaml`](diffhunk://#diff-66d10b0d536d63265c884183009b0c2e3c462ffe64518186b4d11dfd2db77489R8-R11): Added `permissions` block to specify `contents: write` and `issues: write` permissions for the workflow.